### PR TITLE
Prevent invalid SQL detection when keyword is part of something else

### DIFF
--- a/syntaxes/highlight-sql-string.tmLanguage.json
+++ b/syntaxes/highlight-sql-string.tmLanguage.json
@@ -6,8 +6,8 @@
     "patterns": [
         {
             "name": "meta.embedded.block.sql",
-            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace))\\s+",
-            "end": ";|(?=\"\"\"|\"|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace)))",
+            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+",
+            "end": ";|(?=\"\"\"|\"|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+)",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.other.DML.sql"

--- a/syntaxes/highlight-sql-string.tmLanguage.json
+++ b/syntaxes/highlight-sql-string.tmLanguage.json
@@ -6,7 +6,7 @@
     "patterns": [
         {
             "name": "meta.embedded.block.sql",
-            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace))",
+            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace))\\s+",
             "end": ";|(?=\"\"\"|\"|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace)))",
             "beginCaptures": {
                 "1": {

--- a/syntaxes/highlight-sql-string.tmLanguage.json
+++ b/syntaxes/highlight-sql-string.tmLanguage.json
@@ -6,8 +6,8 @@
     "patterns": [
         {
             "name": "meta.embedded.block.sql",
-            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+",
-            "end": ";|(?=\"\"\"|\"|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+)",
+            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))",
+            "end": ";|(?=\"\"\"|\"|'|'''|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+)",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.other.DML.sql"

--- a/syntaxes/highlight-sql-string.tmLanguage.json
+++ b/syntaxes/highlight-sql-string.tmLanguage.json
@@ -6,7 +6,7 @@
     "patterns": [
         {
             "name": "meta.embedded.block.sql",
-            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))",
+            "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+",
             "end": ";|(?=\"\"\"|\"|'|'''|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace|with))\\s+)",
             "beginCaptures": {
                 "1": {


### PR DESCRIPTION
This could happen for instance when a string contained attachedField: attach was incorrectly detected as the start of some SQL. This resulted in a random word being highlighted and the Python syntax highlighting to be messed up.