### PR TITLE
Single quotes support

### DIFF
--- a/syntaxes/highlight-sql-string.tmLanguage.json
+++ b/syntaxes/highlight-sql-string.tmLanguage.json
@@ -7,7 +7,7 @@
         {
             "name": "meta.embedded.block.sql",
             "begin": "\\s*((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace))",
-            "end": ";|(?=\"\"\"|\"|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace)))",
+            "end": ";|(?=\"\"\"|\"|'|'''|--|((?i)(explain|alter|analyze|attach|begin|commit|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|select|update|vacuum|replace)))",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.other.DML.sql"
@@ -24,8 +24,8 @@
         },
         {
             "name": "meta.embedded.block.sql",
-            "begin": "\\s*(--[^\"\\n\\r\\{\\}\\\\]*)",
-            "end": "(?=\"|\\n|\\r)",
+            "begin": "\\s*(--[^\"'\\n\\r\\{\\}\\\\]*)",
+            "end": "(?=\"|'|\\n|\\r)",
             "beginCaptures": {
                 "0": {
                     "name": "comment.line.double-dash.sql"
@@ -36,7 +36,7 @@
                     "include": "source.python#fstring-guts"
                 },
                 {
-                    "match": "[^\"\\n\\r\\{\\}\\\\]*",
+                    "match": "[^\"'\\n\\r\\{\\}\\\\]*",
                     "name": "comment.line.double-dash.sql"
                 }
             ]


### PR DESCRIPTION
Added support for single quotes so the extension works properly for people who use single quotes to create strings.

before:
![before](https://github.com/user-attachments/assets/585dc17d-f462-45d2-a2fd-76c74c26c90c)
(def and pass are white)

after:
![after](https://github.com/user-attachments/assets/76b5396b-ef71-430b-805a-5677dc39bc64)
